### PR TITLE
Support the Windows platform

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python: [3.7, 3.8, 3.9]
     steps: 
       - name: Check out code

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,9 +2,11 @@
 
 ## Development Environment
 
-My primary development environment is IntelliJ (or just Vim) on MacOS, but the
-code and the development process also work in a Linux environment (I've tested
-on Debian buster).  As of now, I do not do any software development on Windows.
+My primary development environment when writing this code was IntelliJ Ultimate
+on MacOS.  I also tested regularly in my Debian Linux development environment.
+I've since moved (mostly against my will) to a Windows development environment for
+day-to-day work, so I've also gone through the effort to support that platform.
+On Windows, I have typically been using PyCharm rather than IntelliJ.   
 
 ## Packaging and Dependencies
 
@@ -59,6 +61,19 @@ Then, install Poetry in your home directory:
 ```
 $ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
 ```
+
+### Windows
+
+First, install Python 3 from your preferred source, either a standard
+installer or a meta-installer like Chocolatey.  Then, install Poetry
+in your home directory:
+
+```
+$ curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+```
+
+The development environment (with the `run` script, etc.) expects a bash shell
+to be available.  It works fine with the standard Git bash.
 
 ## Configure Poetry's Python Interpreter
 
@@ -139,15 +154,15 @@ Usage: run <command>
 
 ## Integration with IntelliJ or PyCharm
 
-For my day-to-day IDE, I use IntelliJ Ultimate with the Python plugin
-installed, which is basically equivalent to PyCharm. By integrating Black and
-Pylint, most everything important that can be done from a shell environment can
-also be done right in IntelliJ.
+I have used both PyCharm and IntelliJ Ultimate (with the Python plugin
+installed).  These two IDEs are basically equivalent except for the location of some
+configuration.  By integrating Black and Pylint, most everything important that
+can be done from a shell environment can also be done right in IntelliJ or PyCharm.
 
-Unfortunately, it is somewhat difficult to provide a working IntelliJ
-configuration that other developers can simply import. There are still some
-manual steps required.  I have checked in a minimal `.idea` directory, so at
-least all developers can share a single inspection profile, etc.
+Unfortunately, it is somewhat difficult to provide a working IntelliJ or
+PyCharm configuration that other developers can simply import. There are still
+some manual steps required.  I have checked in a minimal `.idea` directory, so
+at least all developers can share a single inspection profile, etc.
 
 ### Prerequisites
 
@@ -173,7 +188,7 @@ retained.)
 
 ### Plugins
 
-Install the following plugins:
+If you are using IntelliJ rather than PyCharm, install the following plugins:  
 
 |Plugin|Description|
 |------|-----------|
@@ -187,6 +202,27 @@ Poetry:
 ```
 $ poetry run which python
 ```
+
+> _Note:_ On Windows, remember that Git Bash is is going to give you the translated
+> UNIX-like path.  Work backwards to find the real Windows path. 
+
+
+#### PyCharm
+
+Go to settings and find the `uci-parse` project.  Under **Python Interpreter**,
+select the Python virtualenv from above.
+
+Under **Project Structure**, mark both `src` and `tests` as source folders.  In the
+**Exclude Files** box, enter the following:
+
+```
+.coverage;.coveragerc;.github;.htmlcov;.idea;.isort.cfg;.mypyrc;.mypy_cache;.pre-commit-config.yaml;.pylintrc;.pytest_cache;.readthedocs.yml;.tox;.toxrc;build;dist;docs/_build;out;poetry.lock;run
+```
+
+Finally, go to the gear icon in the project panel, and uncheck **Show Excluded
+Files**.  This will hide the files and directories that were excluded above.
+
+#### IntelliJ 
 
 Right click on the `uci-parse` project in IntelliJ's project explorer and
 choose **Open Module Settings**.  
@@ -222,28 +258,33 @@ module configuration.
 Unit tests are written using [Pytest](https://docs.pytest.org/en/latest/), 
 and API documentation is written 
 using [Google Style Python Docstring](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).  
-However, neither of these is the default in IntelliJ.
+However, neither of these is the default in IntelliJ or PyCharm.
 
-Go to IntelliJ preferences, then select **Tools > Python Integrated Tools**.
-Under **Testing > Default test runner**, select _pytest_.  Under 
-**Docstrings > Docstring format**, select _Google_. Click **OK**.
+In settings, go to **Tools > Python Integrated Tools**.  Under **Testing >
+Default test runner**, select _pytest_.  Under **Docstrings > Docstring
+format**, select _Google_.
 
 ### Running Unit Tests
 
-Use **Build > Rebuild Project**, just to be sure that everything is up-to-date.
-Then, right click on the `tests` folder in IntelliJ's project explorer and
-choose **Run 'pytest in tests'**.  Make sure that all of the tests pass.
+If you are using IntelliJ, first use **Build > Rebuild Project**, just to be
+sure that everything is up-to-date.
+
+In either IntelliJ or PyCharm, right click on the `tests` folder in the
+project explorer and choose **Run 'pytest in tests'**.  Make sure that all of
+the tests pass. 
 
 ### External Tools
 
-Optionally, you might want to set up external tools in IntelliJ for some of
-common developer tasks: code reformatting and the PyLint and MyPy checks.  One
-nice advantage of doing this is that you can configure an output filter, which
-makes the Pylint and MyPy errors clickable in IntelliJ.  To set up external
-tools, go to IntelliJ preferences and find **Tools > External Tools**.  Add the
-tools as described below.
+Optionally, you might want to set up external tools in IntelliJ or PyCharm for
+some of common developer tasks: code reformatting and the PyLint and MyPy
+checks.  One nice advantage of doing this is that you can configure an output
+filter, which makes the Pylint and MyPy errors clickable in IntelliJ.  To set
+up external tools, go to IntelliJ or PyCharm settings and find **Tools >
+External Tools**.  Add the tools as described below. 
 
-#### Format Code
+#### Linux or MacOS
+
+##### Format Code
 
 |Field|Value|
 |-----|-----|
@@ -259,7 +300,7 @@ tools as described below.
 |Make console active on message in stderr|_Unchecked_|
 |Output filters|_Empty_|
 
-#### Run MyPy Checks
+##### Run MyPy Checks
 
 |Field|Value|
 |-----|-----|
@@ -275,7 +316,7 @@ tools as described below.
 |Make console active on message in stderr|_Checked_|
 |Output filters|`$FILE_PATH$:$LINE$:$COLUMN$:.*`|
 
-#### Run Pylint Checks
+##### Run Pylint Checks
 
 |Field|Value|
 |-----|-----|
@@ -284,6 +325,60 @@ tools as described below.
 |Group|`Developer Tools`|
 |Program|`$ProjectFileDir$/run`|
 |Arguments|`pylint`|
+|Working directory|`$ProjectFileDir$`|
+|Synchronize files after execution|_Unchecked_|
+|Open console for tool outout|_Checked_|
+|Make console active on message in stdout|_Checked_|
+|Make console active on message in stderr|_Checked_|
+|Output filters|`$FILE_PATH$:$LINE$:$COLUMN.*`|
+
+#### Windows
+
+On Windows, PyCharm and IntelliJ have problems invoking the `run` script,
+even via the Git Bash interpreter.  I have created a Powershell script
+`tools.ps1` that can be used instead.
+
+##### Format Code
+
+|Field|Value|
+|-----|-----|
+|Name|`Format Code`|
+|Description|`Run the Black and isort code formatters`|
+|Group|`Developer Tools`|
+|Program|`powershell.exe`|
+|Arguments|`-executionpolicy bypass -File tools.ps1 format`|
+|Working directory|`$ProjectFileDir$`|
+|Synchronize files after execution|_Checked_|
+|Open console for tool outout|_Checked_|
+|Make console active on message in stdout|_Unchecked_|
+|Make console active on message in stderr|_Unchecked_|
+|Output filters|_Empty_|
+
+##### Run MyPy Checks
+
+|Field|Value|
+|-----|-----|
+|Name|`Run MyPy Checks`|
+|Description|`Run the MyPy code checks`|
+|Group|`Developer Tools`|
+|Program|`powershell.exe`|
+|Arguments|`-executionpolicy bypass -File tools.ps1 mypy`|
+|Working directory|`$ProjectFileDir$`|
+|Synchronize files after execution|_Unchecked_|
+|Open console for tool outout|_Checked_|
+|Make console active on message in stdout|_Checked_|
+|Make console active on message in stderr|_Checked_|
+|Output filters|`$FILE_PATH$:$LINE$:$COLUMN$:.*`|
+
+##### Run Pylint Checks
+
+|Field|Value|
+|-----|-----|
+|Name|`Run Pylint Checks`|
+|Description|`Run the Pylint code checks`|
+|Group|`Developer Tools`|
+|Program|`powershell.exe`|
+|Arguments|`-executionpolicy bypass -File tools.ps1 pylint`|
 |Working directory|`$ProjectFileDir$`|
 |Synchronize files after execution|_Unchecked_|
 |Open console for tool outout|_Checked_|

--- a/run
+++ b/run
@@ -3,7 +3,6 @@
 
 # Setup the virtual environment via Poetry and install pre-commit hooks
 run_install() {
-   poetry env use python3
    poetry install -v
    poetry run pre-commit install 
 }
@@ -20,6 +19,8 @@ run_requirements() {
 
 # Run the Pylint code checker
 run_pylint() {
+   echo "Running pylint checks..."
+
    poetry run which pylint > /dev/null
    if [ $? != 0 ]; then
       run_install
@@ -30,6 +31,8 @@ run_pylint() {
 
 # Run the MyPy code checker
 run_mypy() {
+   echo "Running mypy checks..."
+
    poetry run which mypy > /dev/null
    if [ $? != 0 ]; then
       run_install
@@ -40,6 +43,8 @@ run_mypy() {
 
 # Run the black code formatter
 run_black() {
+   echo "Running black formatter..."
+
    poetry run which black > /dev/null
    if [ $? != 0 ]; then
       run_install
@@ -50,12 +55,16 @@ run_black() {
 
 # Run the isort import formatter
 run_isort() {
+   echo "Running isort formatter..."
+
    poetry run which isort > /dev/null
    if [ $? != 0 ]; then
       run_install
    fi
 
    poetry run isort src/**/*.py tests/*.py
+
+   echo "done"
 }
 
 # Run the unit tests, optionally with coverage

--- a/tools.ps1
+++ b/tools.ps1
@@ -1,0 +1,34 @@
+# Commands for use as IntelliJ or PyCharm external tools on Windows
+#
+# The run script works fine from a Git Bash shell, but isn't easy to invoke
+# from IntelliJ or PyCharm as an external tool.  This script duplicates the
+# behavior from the run script for the things that I want to be able to invoke.
+# It intentionally does *not* duplicate all of the behavior in the run script.
+# For more information, see the notes in DEVELOPER.md.
+#
+# Run like: powershell.exe -executionpolicy bypass -File tools.ps1 format
+
+param([string]$command)
+Switch ($command)
+{
+    format {
+      Write-Output "Running black formatter..." 
+      poetry run black .
+
+      Write-Output "`nRunning isort formatter..." 
+      $files = cmd /c dir /b /a-d /s src\uciparse tests | findstr \.py$
+      poetry run isort $files
+      Write-Output "done"
+    }
+
+    mypy {
+      Write-Output "Running mypy checks..." 
+      poetry run mypy --config-file=.mypyrc src/uciparse tests
+    }
+
+    pylint {
+      Write-Output "Running pylint checks..." 
+      poetry run pylint --rcfile=.pylintrc src/uciparse tests
+    }
+}
+


### PR DESCRIPTION
This follows the pattern in [apologies-server PR #12](https://github.com/pronovic/apologies-server/pull/12).  The code was already fully portable, so all I needed to do was update documentation and developer processes.