### PR TITLE
Improvements to Read the Docs integration

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -37,4 +37,4 @@ jobs:
         run: poetry install -v
         if: steps.cached-poetry.outputs.cache-hit != 'true'
       - name: Run Tox test suite
-        run: poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+        run: poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"

--- a/.toxrc
+++ b/.toxrc
@@ -2,7 +2,6 @@
 isolated_build = true
 envlist = 
    precommit,
-   docs,
    {py}-{coverage,nocoverage}
 ignore_basepython_conflict = true
 
@@ -20,11 +19,3 @@ commands =
    poetry --version
    poetry version
    poetry run pre-commit run --all-files --show-diff-on-failure
-
-[testenv:docs]
-whitelist_externals = poetry
-changedir = docs
-commands =
-   poetry --version
-   poetry version
-   poetry run sphinx-build -b html -d _build/doctrees . _build/html

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -412,7 +412,7 @@ even via the Git Bash interpreter.  I have created a Powershell script
 
 ### Documentation
 
-Documentation at [Read the Docs](https://uci-parse.readthedocs.io/en/latest/)
+Documentation at [Read the Docs](https://uci-parse.readthedocs.io/en/stable/)
 is generated via a GitHub hook each time code is pushed to master.  So, there
 is no formal release process for the documentation.
 

--- a/PyPI.md
+++ b/PyPI.md
@@ -4,7 +4,7 @@
 ![](https://img.shields.io/pypi/wheel/uciparse.svg)
 ![](https://img.shields.io/pypi/pyversions/uciparse.svg)
 ![](https://github.com/pronovic/uci-parse/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/uci-parse/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/uci-parse/badge/?version=stable&style=flat)
 
 Python 3 library and command line tools to parse, diff, and normalize OpenWRT
 [UCI](https://openwrt.org/docs/guide-user/base-system/uci) configuration files.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![](https://img.shields.io/pypi/wheel/uciparse.svg)
 ![](https://img.shields.io/pypi/pyversions/uciparse.svg)
 ![](https://github.com/pronovic/uci-parse/workflows/Test%20Suite/badge.svg)
-![](https://readthedocs.org/projects/uci-parse/badge/?version=latest&style=flat)
+![](https://readthedocs.org/projects/uci-parse/badge/?version=stable&style=flat)
 
 Python 3 library and command line tools to parse, diff, and normalize OpenWRT
 [UCI](https://openwrt.org/docs/guide-user/base-system/uci) configuration files.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,8 @@ Release v\ |version|
 .. image:: https://github.com/pronovic/uci-parse/workflows/Test%20Suite/badge.svg
     :target: https://github.com/pronovic/uci-parse
 
-.. image:: https://readthedocs.org/projects/uci-parse/badge/?version=latest&style=flat
-    :target: https://uci-parse.readthedocs.io/en/latest/
+.. image:: https://readthedocs.org/projects/uci-parse/badge/?version=stable&style=flat
+    :target: https://uci-parse.readthedocs.io/en/stable/
 
 Python 3 library and command line tools to parse, diff, and normalize OpenWRT
 UCI_ configuration files.

--- a/run
+++ b/run
@@ -112,7 +112,7 @@ run_tox() {
       run_install
    fi
 
-   poetry run tox -c .toxrc -e "precommit,docs,{py}-{coverage,nocoverage}"
+   poetry run tox -c .toxrc -e "precommit,{py}-{coverage,nocoverage}"
 }
 
 # Build the Sphinx documentation for uciparse.readthedocs.io


### PR DESCRIPTION
Read the Docs now offers a config option to build pull requests. The generated documentation is removed 90 days after the branch is deleted. Since I've run into cases where the docs built correctly in the Tox test suite but failed at Read the Docs itself, it seems better to rely on the official Read the Docs build as the merge gate.

At the same time, I adjusted configuration to properly use the stable branch at Read the Docs (which always points at the most recent tagged release), so I converted all of the links to use that URL.