### PR TITLE
Move to a new two-step release process based on cedar-backup3

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,0 +1,13 @@
+Version 0.1.6     unreleased
+
+	* Update build system to use poetry.core
+	* Improve and cleanup the Windows and PyCharm build process.
+	* Fix the GitHub test suite by adding Python version into cache id.
+	* Move to newer versions of various build dependencies (black, isort, etc.).
+	* Standardize on UNIX line endings in Git working copy and PyPI package.
+	* Make improvements to Read the Docs integration, including a PR merge gate.
+	* Clean up badges shown in documentation, so they are links to something sane.
+	* Make improvements to the MyPy and Pylint configuration.
+	* Move to a new two-step release process based on cedar-backup3.
+	* Create a changelog for the first time, along with new release process.
+

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -163,15 +163,16 @@ Usage: run <command>
 - run install: Setup the virtualenv via Poetry and install pre-commit hooks
 - run activate: Print command needed to activate the Poetry virtualenv
 - run requirements: Regenerate the docs/requirements.txt file
-- run checks: Run the PyLint and MyPy code checkers
 - run format: Run the Black code formatter
+- run checks: Run the PyLint and MyPy code checkers
 - run test: Run the unit tests
 - run test -c: Run the unit tests with coverage
 - run test -ch: Run the unit tests with coverage and open the HTML report
-- run tox: Run the broader Tox test suite used by the GitHub CI action
 - run docs: Build the Spinx documentation for uciparse.readthedocs.io
 - run docs -o: Build the Spinx documentation and open in a browser
-- run publish: Tag the current code and publish to PyPI
+- run tox: Run the broader Tox test suite used by the GitHub CI action
+- run release: Release a specific version and tag the code
+- run publish: Publish the current code to PyPI and push to GitHub
 ```
 
 ## Integration with IntelliJ or PyCharm
@@ -419,51 +420,103 @@ is no formal release process for the documentation.
 ### Code
 
 Code is released to [PyPI](https://pypi.org/project/uciparse/).  There is a
-manual process to publish a new release. 
+partially-automated process to publish a new release.  
 
-Before publishing code, you must must have push permissions to the GitHub repo
-and be a collaborator on the PyPI project.
+> _Note:_ In order to publish code, you must must have push permissions to the
+> GitHub repo and be a collaborator on the PyPI project.  Before running this
+> process for the first time, you must set up a PyPI API token and configure
+> Poetry to use it.  (See notes below.)
 
-First, configure an API token which has permission to publish to the
-PyPI project.  This is a one-time step. In your PyPI [account settings](https://pypi.org/manage/account/),
-create an API token with upload permissions.  Save off the token, and then tell
-Poetry to use it, following the [instructions](https://python-poetry.org/docs/repositories/#configuring-credentials):
+Ensure that you are on the `master` branch.  Releases must always be done from
+`master`.
 
-```
-poetry config pypi-token.pypi my-token
-```
-
-To publish a new release, check the current version:
+Ensure that the `Changelog` is up-to-date and reflects all of the changes that
+will be published.  The top line must show your version as unreleased:
 
 ```
-$ poetry version 
-uciparse 0.1.2
+Version 0.1.6      unreleased
 ```
 
-Bump it to whatever version you want to use and commit your changes:
+Run the release step:
 
 ```
-$ poetry version 0.1.3
-Bumping version from 0.1.2 to 0.1.3
-
-$ git add pyproject.toml
-
-$ git commit -m "Release v0.1.3"
+$ run release 0.1.6
 ```
 
-Finally, kick off the custom publish process via the `run` script:
+This updates `pyproject.toml` and the `Changelog` to reflect the released
+version, then commits those changes and tags the code.  Nothing has been pushed
+or published yet, so you can always remove the tag (i.e. `git tag -d v0.1.6`)
+and revert your commit (`git reset HEAD~1`) if you made a mistake.
+
+Finally, publish the release:
 
 ```
 $ run publish
 ```
 
-This tags the code, builds the deployment artifacts, publishes the artifacts to
-PyPI, and pushes the tag to GitHub.  You still need to push your change to
-`pyproject.toml` and any other pending changes to the repo:
+This builds the deployment artifacts, publishes the artifacts to PyPI, and
+pushes the repo to GitHub.  The code will be available on PyPI for others to
+use after a little while, sometimes within a minute or two, and sometimes as
+much as half an hour later.
+
+### Configuring the PyPI API Token
+
+First, in your PyPI [account settings](https://pypi.org/manage/account/),
+create an API token with upload permissions for the uciparse project.
+
+Once you have the token, you will configure Poetry to use it.  Poetry relies on
+the Python keyring to store this secret.  On MacOS, it will use the system
+keyring, and no other setup is required.  
+
+On Debian, the process is more complicated (see the the [keyring documentation](https://pypi.org/project/keyring/) for more details).  
+
+First, install a keyring manager, and then log out:
 
 ```
-$ git push
+$ sudo apt-get install gnome-keyring
+$ exit
 ```
 
-The code will be available on PyPI for others to use after a little while,
-sometimes within a minute or two, and sometimes as much as half an hour later.
+Log back in and initialize your keyring by setting and then removing a dummy
+value:
+
+```
+$ keyring set testvalue "user"
+Password for 'user' in 'testvalue': 
+Please enter password for encrypted keyring: 
+
+$ keyring get testvalue "user"
+Please enter password for encrypted keyring: 
+password
+
+$ keyring del testvalue "user"
+Deleting password for 'user' in 'testvalue':
+```
+
+At this point, the keyring should be fully functional.
+
+Now, configure Poetry following the [instructions](https://python-poetry.org/docs/repositories/#configuring-credentials):
+
+```
+poetry config pypi-token.pypi <the PyPI token>
+```
+
+You will have to type in the same keyring password that you set above.  Note
+that this leaves your actual secret in the command-line history, so make sure
+to scrub it once you're done.
+
+> _Note:_ The user experience is frankly terrible if you're trying to work on a
+> simple SSH session outside of a Linux desktop.  The GNOME keyring manager
+> wants to pop up its dialog to accept your credentials to unlock the keyring.
+> That won't work on an SSH session where there is no GUI.  One alternative is
+> to follow the notes in the [keyring documentation](https://pypi.org/project/keyring/) under
+> **Using Keyring on headless Linux systems**.  This gives you a way to unlock
+> the keyring inside a DBUS session. 
+>
+> The documented process does work, but it's slow and clunky.  And _you must
+> keep the DBUS session open in a separate terminal window for as long as you
+> need to use the keyring_.  When the instructions say "enter your password and
+> type CTRL-D", they mean that literally.  Don't press Enter first or anything
+> like that.  I've found that it works best if I enter the password and press
+> CTRL-D twice so I get back to the DBUS `$` prompt before proceeding in
+> another window.

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ URL for the source package `.tar.gz` file.  Retrieve the source package
 with `wget` and then manually extract it:
 
 ```
-$ wget https://files.pythonhosted.org/.../uciparse-0.1.2.tar.gz
-$ tar zxvf uciparse-0.1.2.tar.gz
-$ cd uciparse-0.1.2
+$ wget https://files.pythonhosted.org/.../uciparse-0.1.6.tar.gz
+$ tar zxvf uciparse-0.1.6.tar.gz
+$ cd uciparse-0.1.6
 ```
 
 Finally, run the custom install script provided with the source package:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,9 @@ description = "Parse and emit OpenWRT uci-format files"
 authors = ["Kenneth J. Pronovici <pronovic@ieee.org>"]
 license = "Apache-2.0"
 readme = "PyPI.md"
-include = ["LICENSE", "uciparse/py.typed", "scripts/*", ]
+homepage = "https://pypi.org/project/uciparse/"
+include = [ "Changelog", "LICENSE", "README.md", "docs", "tests", "scripts", ]
+packages = [ { include = "uciparse", from = "src" } ]
 classifiers=[
    "Programming Language :: Python :: 3",
    "License :: OSI Approved :: Apache Software License",

--- a/run
+++ b/run
@@ -151,7 +151,7 @@ run_release() {
       exit 1
    fi
 
-   VERSION=$1
+   VERSION=$(echo "$1" | sed 's/^v//') # so you can use "0.1.5 or "v0.1.5"
    COPYRIGHT="2020-$(date +'%Y')"
    DATE=$(date +'%d %b %Y')
    TAG="v$VERSION" # follow PEP 440 naming convention

--- a/run
+++ b/run
@@ -144,24 +144,88 @@ run_docs() {
    fi
 }
 
-# Tag the current code and publish to PyPI
+# Release a specific version and tag the code
+run_release() {
+   if [ $# != 1 ]; then
+      echo "run release <version>"
+      exit 1
+   fi
+
+   VERSION=$1
+   COPYRIGHT="2020-$(date +'%Y')"
+   DATE=$(date +'%d %b %Y')
+   TAG="v$VERSION" # follow PEP 440 naming convention
+   FILES="pyproject.toml Changelog"
+   MESSAGE="Release v$VERSION to PyPI"
+
+   if [ "$(git branch -a | grep '^\*' | sed 's/^\* //')" != "master" ]; then
+      echo "*** You are not on master; you cannot release from this branch"
+      exit 1
+   fi
+
+   git tag -l "$TAG" | grep -q "$TAG"
+   if [ $? = 0 ]; then
+      echo "*** Version v$VERSION already tagged"
+      exit 1
+   fi
+
+   head -1 Changelog | grep -q "^Version $VERSION\s\s*unreleased"
+   if [ $? != 0 ]; then
+      echo "*** Unreleased version v$VERSION is not at the head of the Changelog"
+      exit 1
+   fi
+
+   poetry version $VERSION
+   poetry run python ./dos2unix.py pyproject.toml
+
+   # annoyingly, BSD sed and GNU sed are not compatible on the syntax for -i
+   # I failed miserably in all attempts to put the sed command (with empty string) into a variable
+   sed --version 2>&1 | grep -iq "GNU sed"
+   if [ $? = 0 ]; then
+      # GNU sed accepts a bare -i and assumes no backup file
+      sed -i "s/^Version $VERSION\s\s*unreleased/Version $VERSION     $DATE/g" Changelog
+   else
+      # BSD set requires you to set an empty backup file extension
+      sed -i "" "s/^Version $VERSION\s\s*unreleased/Version $VERSION     $DATE/g" Changelog
+   fi
+
+   git diff $FILES
+
+   git commit --no-verify -m "$MESSAGE" $FILES
+   if [ $? != 0 ]; then
+      echo "*** Commit step failed"
+      exit 1
+   fi
+
+   git tag -a "$TAG" -m "$MESSAGE"
+   if [ $? != 0 ]; then
+      echo "*** Tag step failed"
+      exit 1
+   fi
+
+   echo ""
+   echo "*** Version v$VERSION has been released and commited; you may publish now"
+   echo ""
+}
+
+# Publish the current code to PyPI and push to GitHub
 # Before doing this, you must retrieve and configure a local API token
 # For instance: poetry config pypi-token.pypi token --local
 # See: https://python-poetry.org/docs/repositories/#configuring-credentials
 run_publish() {
-   VERSION=$(poetry version)
-   SHORT_VERSION=$(echo "$VERSION" | sed 's/^.* //g')
-
-   git tag -a "v$SHORT_VERSION" -m "Release $VERSION to PyPI"
+   poetry build
    if [ $? != 0 ]; then
-      echo "*** Tag step failed.  Does this version already exist?"
+      echo "*** Build step failed."
       exit 1
    fi
 
-   poetry build
    poetry publish
+   if [ $? != 0 ]; then
+      echo "*** Publish step failed."
+      exit 1
+   fi
 
-   git push origin "v$SHORT_VERSION"
+   git push --follow-tags
 }
 
 # Execute one of the developer tasks
@@ -207,6 +271,10 @@ case $1 in
       shift 1
       run_docs $*
       ;;
+   release)
+      shift 1
+      run_release $*
+      ;;
    publish)
       run_publish
       ;;
@@ -221,15 +289,16 @@ case $1 in
       echo "- run install: Setup the virtualenv via Poetry and install pre-commit hooks"
       echo "- run activate: Print command needed to activate the Poetry virtualenv"
       echo "- run requirements: Regenerate the docs/requirements.txt file"
-      echo "- run checks: Run the PyLint and MyPy code checkers"
       echo "- run format: Run the Black code formatter"
+      echo "- run checks: Run the PyLint and MyPy code checkers"
       echo "- run test: Run the unit tests"
       echo "- run test -c: Run the unit tests with coverage"
       echo "- run test -ch: Run the unit tests with coverage and open the HTML report"
-      echo "- run tox: Run the broader Tox test suite used by the GitHub CI action"
       echo "- run docs: Build the Spinx documentation for uciparse.readthedocs.io"
       echo "- run docs -o: Build the Spinx documentation and open in a browser"
-      echo "- run publish: Tag the current code and publish to PyPI"
+      echo "- run tox: Run the broader Tox test suite used by the GitHub CI action"
+      echo "- run release: Release a specific version and tag the code"
+      echo "- run publish: Publish the current code to PyPI and push to GitHub"
       echo ""
       exit 1
 esac


### PR DESCRIPTION
The existing release process is error-prone.  If I screw something up and release the wrong code (i.e. forget a commit or something) there's no good way to fall back.   This moves to a 2-step process similar to the one that I have been using with [cedar-backup3](https://github.com/pronovic/cedar-backup3).   I have also added a changelog for the first time.   The first step is `run release` which updates the changelog and `pyproject.toml` and tags the code.  The second step is `run publish` which actually publishes the package to PyPI.  If you screw up the release, you can always fall it back by resetting to `HEAD~1` and deleting the tag.

The release process should work the same on all platforms I support - Linux, MacOS, and Windows.   The `run` script works fine with Git Bash on Windows.  The only complication is that I have to work around differing behavior between GNU `sed` and BSD `sed`.

The changelog is still generated manually rather than automatically based on Git commits or something.  Not every Git commit necessarily reflects something that needs to be communicated in the changelog.  I'd prefer to summarize and make the changelog a bit more legible.  (This is the process I've followed for Cedar Backup for ~20 years now, and I'm happy with it.)

I have also made some adjustments to `pyproject.toml` so that more of the original source tree is published in the tarball on PyPI.