### PR TITLE
Exclude generated files in docs/_build from the Python sdist

### DIFF
--- a/.run/commands/poetrybuild.sh
+++ b/.run/commands/poetrybuild.sh
@@ -3,15 +3,22 @@
 
 # Poetry v2 attaches the epoch timestamp (1970-01-01 00:00) to all of the files
 # in the sdist .tar.gz file, rather than the timestamp from the filesystem they
-# were sourced from, as was the behavior in Poetry v1.  To work around this, I'm
-# setting the $SOURCE_DATE_EPOCH to the current UTC epoch seconds value.
-# 
+# were sourced from, as was the behavior in Poetry v1.  To work around this,
+# I'm setting the $SOURCE_DATE_EPOCH to the current UTC epoch seconds value.
 # See also: https://github.com/python-poetry/poetry/issues/10083
+#
+# Due to limitations in Poetry's [tool.poetry] configuration block, there's no
+# simple way to include docs/ in the sdist, while also excluding the generated
+# files in docs/_build.  The cleanest workaround is to remove docs/_build before
+# running the `poetry build` command.  That's clearly a hack, but there's
+# apparently no other alternative.  Technically, this is only necessary for
+# projects that build docs, but it's easiest to just always do the cleanup.
 
 command_poetrybuild() {
    echo "Building release artifacts..."
 
    rm -f dist/*
+   rm -rf docs/_build
 
    poetry version
 

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.2.1     unreleased
+
+	* Exclude generated files in `docs/_build` from the Python sdist.
+
 Version 0.2.0     17 Sep 2025
 
 	* Add a new 'suite -f' command to run faster subset of the suite.


### PR DESCRIPTION
Due to limitations in Poetry's `[tool.poetry]` configuration block, there's no simple way to include `docs/` in the sdist, while also excluding the generated files in `docs/_build`.  The cleanest workaround is to remove `docs/_build` before running the `poetry build` command.  That's clearly a hack, but there's apparently no other alternative.  Technically, this is only necessary for projects that build docs, but it's easiest to just always do the cleanup.